### PR TITLE
Modify aug block in place

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,12 +11,12 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 [extras]
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
+MadNLP = "2621e9c9-9eb4-46b1-8089-e8c72242dfb6"
 NLPModelsIpopt = "f4238b75-b362-5c4c-b852-0801c9a21d71"
 NLPModelsJuMP = "792afdf1-32c1-5681-94e0-d7bf7a5df49e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SolverCore = "ff4d7338-4cf1-434d-91df-b86cb86fb843"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-MadNLP = "2621e9c9-9eb4-46b1-8089-e8c72242dfb6"
 
 [targets]
 test = ["Ipopt", "JuMP", "NLPModelsIpopt", "NLPModelsJuMP", "Random", "SolverCore", "Test", "MadNLP"]

--- a/src/BlockNLPModels.jl
+++ b/src/BlockNLPModels.jl
@@ -10,7 +10,8 @@ export DualizedNLPBlockModel
 export AugmentedNLPBlockModel
 export FullSpaceModel
 export add_block, add_links, n_constraints,
-       get_linking_matrix, get_linking_matrix_blocks, get_rhs_vector
+       get_linking_matrix, get_linking_matrix_blocks, 
+       get_rhs_vector, update_dual!, update_primal!
 
 """
     AbstractBlockNLPModel

--- a/src/augmented_block.jl
+++ b/src/augmented_block.jl
@@ -122,32 +122,32 @@ function get_hessian(m::AugmentedNLPBlockModel;
 end
 
 """
-    update_primal_sol!(
+    update_primal!(
       nlp::AugmentedNLPBlockModel, 
       sol::AbstractVector
     )
-Updates the primal solution for the augmented nlp block `nlp`.
+Updates the primal solution estimate for the augmented nlp block `nlp`.
 
 # Arguments
 - `nlp::AugmentedNLPBlockModel`: the subproblem 
 - `sol::AbstractVector`: vector of primal variables
 """
-function update_primal_sol!(nlp::AugmentedNLPBlockModel, sol::AbstractVector)
+function update_primal!(nlp::AugmentedNLPBlockModel, sol::AbstractVector)
     nlp.sol .= sol
 end
 
 """
-    update_dual_sol!(
+    update_dual!(
       nlp::AugmentedNLPBlockModel, 
       λ::AbstractVector, 
     )
-Updates the dual solution in-place for the augmented nlp block `nlp`.
+Updates the dual solution estimate in-place for the augmented nlp block `nlp`.
 
 # Arguments
 - `nlp::AugmentedNLPBlockModel`: the subproblem 
 - `λ::AbstractVector`: vector of dual variables
 """
-function update_dual_sol!(nlp::AugmentedNLPBlockModel, λ::AbstractVector)
+function update_dual!(nlp::AugmentedNLPBlockModel, λ::AbstractVector)
     nlp.λ .= λ
 end
 

--- a/src/augmented_block.jl
+++ b/src/augmented_block.jl
@@ -123,13 +123,13 @@ end
 
 """
     update_primal_sol!(
-      nlp::AbstractNLPModel, 
+      nlp::AugmentedNLPBlockModel, 
       sol::AbstractVector
     )
 Updates the primal solution for the augmented nlp block `nlp`.
 
 # Arguments
-- `nlp::AbstractNLPModel`: the subproblem 
+- `nlp::AugmentedNLPBlockModel`: the subproblem 
 - `sol::AbstractVector`: vector of primal variables
 """
 function update_primal_sol!(nlp::AugmentedNLPBlockModel, sol::AbstractVector)
@@ -138,13 +138,13 @@ end
 
 """
     update_dual_sol!(
-      nlp::AbstractNLPModel, 
+      nlp::AugmentedNLPBlockModel, 
       λ::AbstractVector, 
     )
 Updates the dual solution in-place for the augmented nlp block `nlp`.
 
 # Arguments
-- `nlp::AbstractNLPModel`: the subproblem 
+- `nlp::AugmentedNLPBlockModel`: the subproblem 
 - `λ::AbstractVector`: vector of dual variables
 """
 function update_dual_sol!(nlp::AugmentedNLPBlockModel, λ::AbstractVector)

--- a/src/augmented_block.jl
+++ b/src/augmented_block.jl
@@ -121,6 +121,36 @@ function get_hessian(m::AugmentedNLPBlockModel;
     return H
 end
 
+"""
+    update_primal_sol!(
+      nlp::AbstractNLPModel, 
+      sol::AbstractVector
+    )
+Updates the primal solution for the augmented nlp block `nlp`.
+
+# Arguments
+- `nlp::AbstractNLPModel`: the subproblem 
+- `sol::AbstractVector`: vector of primal variables
+"""
+function update_primal_sol!(nlp::AugmentedNLPBlockModel, sol::AbstractVector)
+    nlp.sol .= sol
+end
+
+"""
+    update_dual_sol!(
+      nlp::AbstractNLPModel, 
+      λ::AbstractVector, 
+    )
+Updates the dual solution in-place for the augmented nlp block `nlp`.
+
+# Arguments
+- `nlp::AbstractNLPModel`: the subproblem 
+- `λ::AbstractVector`: vector of dual variables
+"""
+function update_dual_sol!(nlp::AugmentedNLPBlockModel, λ::AbstractVector)
+    nlp.λ .= λ
+end
+
 function NLPModels.obj(nlp::AugmentedNLPBlockModel, x::AbstractVector)
     local_sol = deepcopy(nlp.sol)
     local_sol[nlp.subproblem.var_idx] = x

--- a/src/dualized_block.jl
+++ b/src/dualized_block.jl
@@ -30,6 +30,21 @@ function DualizedNLPBlockModel(nlp::AbstractNLPModel, λ::AbstractVector, A::Abs
     return DualizedNLPBlockModel(meta, Counters(), nlp, λ, A)
 end
 
+"""
+    update_dual_sol!(
+      nlp::DualizedNLPBlockModel, 
+      λ::AbstractVector, 
+    )
+Updates the dual solution in-place for the dualized nlp block `nlp`.
+
+# Arguments
+- `nlp::DualizedNLPBlockModel`: the subproblem 
+- `λ::AbstractVector`: vector of dual variables
+"""
+function update_dual_sol!(nlp::DualizedNLPBlockModel, λ::AbstractVector)
+    nlp.λ .= λ
+end
+
 function NLPModels.obj(nlp::DualizedNLPBlockModel, x::AbstractVector)
     n = nlp.problem_block.meta.nvar
     return obj(nlp.problem_block, x) + dot(nlp.λ, nlp.A, x)

--- a/src/dualized_block.jl
+++ b/src/dualized_block.jl
@@ -31,7 +31,7 @@ function DualizedNLPBlockModel(nlp::AbstractNLPModel, λ::AbstractVector, A::Abs
 end
 
 """
-    update_dual_sol!(
+    update_dual!(
       nlp::DualizedNLPBlockModel, 
       λ::AbstractVector, 
     )
@@ -41,7 +41,7 @@ Updates the dual solution in-place for the dualized nlp block `nlp`.
 - `nlp::DualizedNLPBlockModel`: the subproblem 
 - `λ::AbstractVector`: vector of dual variables
 """
-function update_dual_sol!(nlp::DualizedNLPBlockModel, λ::AbstractVector)
+function update_dual!(nlp::DualizedNLPBlockModel, λ::AbstractVector)
     nlp.λ .= λ
 end
 

--- a/src/full_space.jl
+++ b/src/full_space.jl
@@ -196,7 +196,7 @@ end
 
 function NLPModels.jac_coord!(nlp::FullSpaceModel, x::AbstractVector, vals::AbstractVector)
     @lencheck nlp.meta.nvar x
-    @lencheck nlp.meta.nnzj vals
+    # @lencheck nlp.meta.nnzj vals
     increment!(nlp, :neval_jac)
     nb = nlp.blocknlp.problem_size.block_counter
     idx = 0
@@ -210,7 +210,8 @@ function NLPModels.jac_coord!(nlp::FullSpaceModel, x::AbstractVector, vals::Abst
         end
     end
     r, c, v = findnz(get_linking_matrix(nlp.blocknlp))
-    vals[idx+1:end] .= v
+    # vals[idx+1:end] .= v
+    vals[idx+1:nlp.meta.nnzj] .= v # for madnlpß
     return vals
 end
 

--- a/src/full_space.jl
+++ b/src/full_space.jl
@@ -196,7 +196,7 @@ end
 
 function NLPModels.jac_coord!(nlp::FullSpaceModel, x::AbstractVector, vals::AbstractVector)
     @lencheck nlp.meta.nvar x
-    # @lencheck nlp.meta.nnzj vals
+    # @lencheck nlp.meta.nnzj vals # for madnlp
     increment!(nlp, :neval_jac)
     nb = nlp.blocknlp.problem_size.block_counter
     idx = 0
@@ -211,7 +211,7 @@ function NLPModels.jac_coord!(nlp::FullSpaceModel, x::AbstractVector, vals::Abst
     end
     r, c, v = findnz(get_linking_matrix(nlp.blocknlp))
     # vals[idx+1:end] .= v
-    vals[idx+1:nlp.meta.nnzj] .= v # for madnlpß
+    vals[idx+1:nlp.meta.nnzj] .= v # for madnlp
     return vals
 end
 

--- a/test/simple_block_model.jl
+++ b/test/simple_block_model.jl
@@ -68,12 +68,14 @@ end
     @test cons(fm, x) ≈ g(x)
     @test jac(fm, x) ≈ J(x)
     @test hess(fm, x, y) ≈ tril(H(x, y))
+
+    # Solve the full-space problem with MadNLP
     stats = ipopt(fm, print_level = 0)
     @test stats.solution ≈ [0.41, 1, 1]
 
     # Solve the full-space problem with MadNLP
-    # To Do: Why MadNLP throws an error?
-    # madnlp(fm)
+    stats = madnlp(fm, print_level = MadNLP.WARN)
+    @test stats.solution ≈ [0.4099999816058684, 1.000000008750505, 1.000000009643627]
 end
 
 @testset "Testing dualized_block.jl" begin


### PR DESCRIPTION
Made some small changes to the code:
- Added functions to modify `AugmentedNLPBlockModel` in-place
- Made `fullspace.jl` compatible with MadNLP. Now `BlockNLPModels.jl` passes all tests with `MadNLP.jl` as the NLP solver.